### PR TITLE
Include 'x-amz-meta-' prefix in metadata headers in response

### DIFF
--- a/internal/s3api/s3_object_handlers.go
+++ b/internal/s3api/s3_object_handlers.go
@@ -162,7 +162,7 @@ func updateMetadataHeaders(obj *nats.ObjectInfo, w http.ResponseWriter) {
 			if k == "" {
 				continue
 			}
-			w.Header().Set(k, v)
+			w.Header().Set(fmt.Sprintf("x-amz-meta-%s", k), v)
 		}
 	}
 }


### PR DESCRIPTION
## Overview
Include 'x-amz-meta-' prefix in metadata headers in response

