### PR TITLE
feat: add graceful shutdown support and improve documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 
 FROM golang:${GO_VERSION}-alpine AS build
 WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -66,7 +66,12 @@ Follow these steps to spin up NATS-S3, integrated with NATS server, and use AWS 
 docker run -p 4222:4222 -ti nats:latest -js
 ```
 
-3) Create a credentials file
+3) Build the nats-s3 gateway
+```bash
+make build
+```
+
+4) Create a credentials file
 ```bash
 cat > credentials.json <<EOF
 {
@@ -80,16 +85,16 @@ cat > credentials.json <<EOF
 EOF
 ```
 
-4) Start the nats-s3 gateway
+5) Start the nats-s3 gateway
 ```bash
 # In a separate terminal
-./nats-s3 \
+./bin/nats-s3 \
   --listen 0.0.0.0:5222 \
   --natsServers nats://127.0.0.1:4222 \
   --s3.credentials credentials.json
 ```
 
-5) Configure your AWS CLI to use the same credentials
+6) Configure your AWS CLI to use the same credentials
 ```bash
 export AWS_ACCESS_KEY_ID=my-access-key
 export AWS_SECRET_ACCESS_KEY=my-secret-key
@@ -97,33 +102,33 @@ export AWS_SECRET_ACCESS_KEY=my-secret-key
 export AWS_DEFAULT_REGION=us-east-1
 ```
 
-6) Create a bucket
+7) Create a bucket
 ```bash
 aws s3 mb s3://bucket1 --endpoint-url=http://localhost:5222
 ```
 
-7) List buckets
+8) List buckets
 ```bash
 aws s3 ls --endpoint-url=http://localhost:5222
 ```
 
-8) Put an object
+9) Put an object
 ```bash
 echo "hello world" > file.txt
 aws s3 cp file.txt s3://bucket1/hello.txt --endpoint-url=http://localhost:5222
 ```
 
-9) List bucket contents
+10) List bucket contents
 ```bash
 aws s3 ls s3://bucket1 --endpoint-url=http://localhost:5222
 ```
 
-10) Download the object
+11) Download the object
 ```bash
 aws s3 cp s3://bucket1/hello.txt ./hello_copy.txt --endpoint-url=http://localhost:5222
 ```
 
-11) Delete the object
+12) Delete the object
 ```bash
 aws s3 rm s3://bucket1/hello.txt --endpoint-url=http://localhost:5222
 ```
@@ -143,7 +148,7 @@ make build
 
 Run
 ```shell
-./nats-s3 \
+./bin/nats-s3 \
   --listen 0.0.0.0:5222 \
   --natsServers nats://127.0.0.1:4222 \
   --s3.credentials credentials.json

--- a/internal/client/nats_client.go
+++ b/internal/client/nats_client.go
@@ -76,3 +76,10 @@ func (c *Client) ID() string {
 func (c *Client) Name() string {
 	return fmt.Sprintf("%s:%s", c.kind, c.id)
 }
+
+// Close closes the NATS connection.
+func (c *Client) Close() {
+	if c.nc != nil {
+		c.nc.Close()
+	}
+}

--- a/internal/client/nats_object_client.go
+++ b/internal/client/nats_object_client.go
@@ -479,3 +479,10 @@ func removeTagsFromMetadata(metadata map[string]string) {
 		}
 	}
 }
+
+// Close closes the underlying NATS connection.
+func (c *NatsObjectClient) Close() {
+	if c.client != nil {
+		c.client.Close()
+	}
+}

--- a/internal/s3api/s3_gateway.go
+++ b/internal/s3api/s3_gateway.go
@@ -233,3 +233,10 @@ func addBucketSubresource(r *mux.Router, method, sub string, h http.HandlerFunc)
 func addObjectSubresource(r *mux.Router, method, sub string, h http.HandlerFunc) {
 	r.Methods(method).Path("/{key:.+}").Queries(sub, "").HandlerFunc(h)
 }
+
+// Close closes the underlying NATS connection.
+func (s *S3Gateway) Close() {
+	if s.client != nil {
+		s.client.Close()
+	}
+}

--- a/internal/server/gateway_server.go
+++ b/internal/server/gateway_server.go
@@ -1,9 +1,12 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/go-kit/log"
@@ -138,6 +141,40 @@ func (s *GatewayServer) Start() error {
 		MaxHeaderBytes: 1 << 20, // 1 MB
 	}
 
-	logging.Info(s.logger, "msg", fmt.Sprintf("Listening for HTTP requests on %s", s.config.Endpoint))
-	return srv.ListenAndServe()
+	// Channel to listen for errors from the HTTP server
+	serverErrors := make(chan error, 1)
+
+	// Start HTTP server in a goroutine
+	go func() {
+		logging.Info(s.logger, "msg", fmt.Sprintf("Listening for HTTP requests on %s", s.config.Endpoint))
+		serverErrors <- srv.ListenAndServe()
+	}()
+
+	// Channel to listen for interrupt signals
+	shutdown := make(chan os.Signal, 1)
+	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
+
+	// Block until we receive a signal or server error
+	select {
+	case err := <-serverErrors:
+		return fmt.Errorf("server error: %w", err)
+
+	case sig := <-shutdown:
+		logging.Info(s.logger, "msg", fmt.Sprintf("Received signal %v, starting graceful shutdown", sig))
+
+		// Give outstanding requests 30 seconds to complete
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		if err := srv.Shutdown(ctx); err != nil {
+			logging.Error(s.logger, "msg", "Error during server shutdown", "err", err)
+			return fmt.Errorf("could not gracefully shutdown server: %w", err)
+		}
+
+		// Close NATS connection
+		s.s3Gateway.Close()
+		logging.Info(s.logger, "msg", "Server shutdown completed")
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Overview
Add graceful shutdown support and improve documentation

## Changes
- Add graceful shutdown handling for SIGINT and SIGTERM signals
     - Implement Close() methods for proper NATS connection cleanup
     - Give active requests 30 seconds to complete before shutdown
     - Fix README quick start to include 'make build' step
     - Update binary path from ./nats-s3 to ./bin/nats-s3 in docs
